### PR TITLE
fix: skip non-scroll mouse events to prevent image flicker

### DIFF
--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -78,6 +78,13 @@ pub fn run(opts: ViewerOptions) -> io::Result<()> {
             let mut coalesced = false;
             while !quit && event::poll(Duration::ZERO)? {
                 let ev = event::read()?;
+                if let Event::Mouse(me) = &ev
+                    && !matches!(
+                        me.kind,
+                        MouseEventKind::ScrollDown | MouseEventKind::ScrollUp
+                    ) {
+                        continue;
+                    }
                 quit = handle_event(&mut state, ev);
                 coalesced = true;
             }


### PR DESCRIPTION
## Summary
- Filter out non-scroll mouse events (moves, button presses, drags) in the event loop
- Applied in both the main event read and the coalescing drain loop
- Prevents unnecessary redraws that cause severe image flicker when moving the mouse over rendered images
- Only ScrollDown and ScrollUp mouse events are processed; all others are skipped early

Note: Some minor image discoloration may still occur during rapid scrolling — this is a pre-existing issue with terminal image protocol redraws and is not introduced by this change.

## Test plan
- [x] `cargo test` passes
- [x] `cargo clippy` clean
- [x] Manual: move mouse over rendered images — no flicker
- [x] Scroll with mouse wheel still works normally