### PR TITLE
fix(link): stop showing raw URLs inline, show link text in picker

### DIFF
--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -882,15 +882,7 @@ impl<'a> Renderer<'a> {
                 self.link_url = dest_url.to_string();
             }
             Event::End(TagEnd::Link) => {
-                let url = std::mem::take(&mut self.link_url);
-                self.push_span(
-                    &format!(" {}", url),
-                    Style {
-                        fg: Some(self.theme.link_url),
-                        link_url: Some(url),
-                        ..Default::default()
-                    },
-                );
+                self.link_url.clear();
                 self.in_link = false;
             }
 

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -540,17 +540,29 @@ impl ViewerState {
 
         // Build link list
         self.link_entries.clear();
-        let mut seen_urls = std::collections::HashSet::new();
+        let mut prev_url: Option<String> = None;
         for line in &self.wrapped {
             for span in &line.spans {
-                if let Some(ref url) = span.style.link_url
-                    && seen_urls.insert(url.clone())
-                {
+                if let Some(ref url) = span.style.link_url {
                     let text = span.text.trim().to_string();
+                    if text.is_empty() {
+                        continue;
+                    }
+                    // Merge adjacent fragments of the same link (from line wrapping)
+                    if prev_url.as_deref() == Some(url.as_str())
+                        && let Some(last) = self.link_entries.last_mut()
+                    {
+                        last.text.push(' ');
+                        last.text.push_str(&text);
+                        continue;
+                    }
                     self.link_entries.push(LinkEntry {
                         url: url.clone(),
                         text,
                     });
+                    prev_url = Some(url.clone());
+                } else {
+                    prev_url = None;
                 }
             }
         }
@@ -2438,18 +2450,53 @@ fn render_link_picker_overlay(stdout: &mut io::Stdout, state: &ViewerState) -> i
 
     for (i, entry) in entries.iter().enumerate().take(shown) {
         let num = format!(" {:>2}. ", i + 1);
-        let available = box_w.saturating_sub(2 + num.chars().count());
-        let url_display: String = if entry.url.chars().count() > available {
-            entry
-                .url
-                .chars()
-                .take(available.saturating_sub(1))
-                .collect::<String>()
-                + "…"
+        let num_len = num.chars().count();
+        let available = box_w.saturating_sub(2 + num_len);
+        let has_text = !entry.text.is_empty() && entry.text != entry.url;
+
+        let (text_part, url_part) = if has_text {
+            let sep = " → ";
+            let sep_len = sep.chars().count();
+            let text_len = entry.text.chars().count();
+            let url_len = entry.url.chars().count();
+
+            if text_len + sep_len + url_len <= available {
+                (format!("{}{}", entry.text, sep), entry.url.clone())
+            } else if text_len + sep_len + 3 <= available {
+                let url_budget = available - text_len - sep_len;
+                let truncated_url: String = entry
+                    .url
+                    .chars()
+                    .take(url_budget.saturating_sub(1))
+                    .collect::<String>()
+                    + "…";
+                (format!("{}{}", entry.text, sep), truncated_url)
+            } else {
+                // Even text barely fits — just show truncated text
+                let truncated: String = entry
+                    .text
+                    .chars()
+                    .take(available.saturating_sub(1))
+                    .collect::<String>()
+                    + "…";
+                (truncated, String::new())
+            }
         } else {
-            entry.url.clone()
+            let url_display: String = if entry.url.chars().count() > available {
+                entry
+                    .url
+                    .chars()
+                    .take(available.saturating_sub(1))
+                    .collect::<String>()
+                    + "…"
+            } else {
+                entry.url.clone()
+            };
+            (String::new(), url_display)
         };
-        let padding = box_w.saturating_sub(2 + num.chars().count() + url_display.chars().count());
+
+        let content_len = text_part.chars().count() + url_part.chars().count();
+        let padding = box_w.saturating_sub(2 + num_len + content_len);
 
         queue!(
             stdout,
@@ -2460,7 +2507,9 @@ fn render_link_picker_overlay(stdout: &mut io::Stdout, state: &ViewerState) -> i
             SetForegroundColor(theme.overlay_selected_fg),
             Print(&num),
             SetForegroundColor(theme.overlay_text),
-            Print(&url_display),
+            Print(&text_part),
+            SetForegroundColor(theme.link_url),
+            Print(&url_part),
             Print(" ".repeat(padding)),
             SetForegroundColor(theme.overlay_border),
             Print("│"),

--- a/test.md
+++ b/test.md
@@ -24,6 +24,8 @@ Visit [Rust](https://www.rust-lang.org) or check out [mdterm on GitHub](https://
 
 Multiple links: [Google](https://google.com), [Wikipedia](https://en.wikipedia.org), [Hacker News](https://news.ycombinator.com).
 
+Same-target links: [readme 1](README.md) and [readme 2](README.md) — both point to README.md but have different text. Only the text should show inline. Press `f` to see both entries with text and URL.
+
 Press `f` to open the link picker and jump to any link.
 
 ## Images


### PR DESCRIPTION
## Summary

- **Inline links** no longer show the raw URL after the link text — just the text, like GitHub renders it (fixes #22)
- **Link picker** (`f` key) now shows `text → URL` for each entry instead of just the URL, and same-URL links with different text get separate entries (fixes #23)

## Changes

- `markdown.rs`: Remove URL span from `End(TagEnd::Link)` handler
- `viewer.rs`: Replace URL-based dedup with adjacency-based merging for link extraction; update overlay to render `text → URL` with distinct colors

## Test plan

- [x] Open `test.md`, verify links show only text inline (no URL appended)
- [x] Press `f`, verify each link shows "text → URL" format
- [x] Confirm same-URL links (`readme 1`, `readme 2`) appear as separate entries
- [x] Image links still show URL-only in the picker

Closes #22, closes #23