### PR TITLE
fix: enable `use-dev-tty` feature in crossterm to fix pipe on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 pulldown-cmark = "0.11"
-crossterm = "0.28"
+crossterm = { version = "0.28", features = ["use-dev-tty"] }
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }
 clap = { version = "4", features = ["derive"] }
 regex = "1"


### PR DESCRIPTION
### Issue
On macOS, when stdin is a pipe, crossterm's default event source (mio-based) calls tty_fd(), which correctly opens /dev/tty as a fallback for keyboard input. However, it then tries to register that fd with mio's kqueue backend (macOS specific), which fails because the fd is not in non-blocking mode and /dev/tty is not a supported fd type for kqueue registration:

```sh
$ cat README.md | mdterm
Viewer error: Failed to initialize input reader
```

### Fix
This enables crossterms `use-dev-tty` feature, which switches the event source from mio/kqueue to a poll()-based backend that handles /dev/tty correctly.