### PR TITLE
fix config dir

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -39,5 +39,13 @@ impl Config {
 }
 
 fn config_path() -> Option<PathBuf> {
+    // Check XDG-style ~/.config first (takes precedence on all platforms),
+    // then fall back to the platform config dir (e.g. ~/Library/Preferences on macOS).
+    let xdg = dirs::home_dir().map(|h| h.join(".config").join("mdterm").join("config.toml"));
+    if let Some(ref p) = xdg {
+        if p.exists() {
+            return xdg;
+        }
+    }
     dirs::config_dir().map(|d| d.join("mdterm").join("config.toml"))
 }


### PR DESCRIPTION
> on macOS, dirs::config_dir() returns ~/Library/Preferences rather than ~/.config, so the config file at
  ~/.config/mdterm/config.toml was never found and the default (dark) theme was always used. The fix checks ~/.config first, then falls back to the platform dir.


Not super confident about this but I tried to change to light theme and it didn't work. My agent suggested this fix to load the correct config directory, which does work on my (m1 mac) at least.