### PR TITLE
feat(themes): add support for custom themes via external TOML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,11 @@ Create `~/.config/mdterm/config.toml`:
 theme = "dark"          # "dark" or "light"
 line_numbers = false     # show line numbers in code blocks
 width = 0               # display width (0 = auto)
+theme_dark = "github-dark"   # Theme names for
+theme_light = "github-light" # each mode
 ```
+Themes are storage in `~/.config/mdterm/themes` as `<theme>.toml`
+Theme samples can be found in `code/themes`
 
 CLI flags override config file settings.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,9 @@ pub struct Config {
     pub line_numbers: bool,
     #[serde(default)]
     pub width: usize,
+
+    pub theme_dark: Option<String>,
+    pub theme_light: Option<String>,
 }
 
 fn default_theme() -> String {
@@ -22,6 +25,8 @@ impl Default for Config {
             theme: default_theme(),
             line_numbers: false,
             width: 0,
+            theme_dark: None,
+            theme_light: None,
         }
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,4 +1,7 @@
+use crate::config::Config;
 use crossterm::style::Color;
+use std::collections::HashMap;
+use std::fs;
 
 #[derive(Clone)]
 pub struct Theme {
@@ -93,576 +96,220 @@ pub struct Theme {
     is_dark: bool,
 }
 
+fn load_theme_overrides(theme_name: Option<String>) -> HashMap<String, Color> {
+    let mut overrides = HashMap::new();
+
+    let name = match theme_name {
+        Some(n) => n,
+        None => return overrides,
+    };
+
+    let theme_path = dirs::config_dir().map(|d| {
+        d.join("mdterm")
+            .join("themes")
+            .join(format!("{}.toml", name))
+    });
+
+    let path = match theme_path {
+        Some(p) => p,
+        None => return overrides,
+    };
+
+    // Parse the target theme TOML file into a flat key-value map
+    if let Ok(contents) = fs::read_to_string(path)
+        && let Ok(theme_map) = toml::from_str::<HashMap<String, String>>(&contents)
+    {
+        for (key, val) in theme_map {
+            let hex = val.trim_start_matches('#');
+            if hex.len() == 6 {
+                let r = u8::from_str_radix(&hex[0..2], 16).unwrap_or(0);
+                let g = u8::from_str_radix(&hex[2..4], 16).unwrap_or(0);
+                let b = u8::from_str_radix(&hex[4..6], 16).unwrap_or(0);
+                overrides.insert(key, Color::Rgb { r, g, b });
+            }
+        }
+    }
+
+    overrides
+}
+
 impl Theme {
     pub fn dark() -> Self {
+        let config = Config::load();
+        let overrides = load_theme_overrides(config.theme_dark);
+
+        macro_rules! resolve_color {
+            ($key:expr, $r:expr, $g:expr, $b:expr) => {
+                overrides.get($key).copied().unwrap_or(Color::Rgb {
+                    r: $r,
+                    g: $g,
+                    b: $b,
+                })
+            };
+        }
+
         Self {
             is_dark: true,
+            bg: resolve_color!("bg", 30, 30, 46),
+            fg: resolve_color!("fg", 205, 214, 244),
 
-            bg: Color::Rgb {
-                r: 30,
-                g: 30,
-                b: 46,
-            },
-            fg: Color::Rgb {
-                r: 205,
-                g: 214,
-                b: 244,
-            },
+            border: resolve_color!("border", 68, 71, 90),
+            title: resolve_color!("title", 147, 153, 178),
+            position: resolve_color!("position", 108, 112, 134),
+            help_hint: resolve_color!("help_hint", 88, 91, 112),
+            scrollbar_track: resolve_color!("scrollbar_track", 49, 50, 68),
+            scrollbar_thumb: resolve_color!("scrollbar_thumb", 127, 132, 156),
 
-            border: Color::Rgb {
-                r: 68,
-                g: 71,
-                b: 90,
-            },
-            title: Color::Rgb {
-                r: 147,
-                g: 153,
-                b: 178,
-            },
-            position: Color::Rgb {
-                r: 108,
-                g: 112,
-                b: 134,
-            },
-            help_hint: Color::Rgb {
-                r: 88,
-                g: 91,
-                b: 112,
-            },
-            scrollbar_track: Color::Rgb {
-                r: 49,
-                g: 50,
-                b: 68,
-            },
-            scrollbar_thumb: Color::Rgb {
-                r: 127,
-                g: 132,
-                b: 156,
-            },
+            h1: resolve_color!("h1", 205, 214, 244),
+            h2: resolve_color!("h2", 137, 180, 250),
+            h3: resolve_color!("h3", 203, 166, 247),
+            h4: resolve_color!("h4", 166, 227, 161),
+            h5: resolve_color!("h5", 249, 226, 175),
+            h6: resolve_color!("h6", 127, 132, 156),
+            heading_separator: resolve_color!("heading_separator", 49, 50, 68),
 
-            h1: Color::Rgb {
-                r: 205,
-                g: 214,
-                b: 244,
-            },
-            h2: Color::Rgb {
-                r: 137,
-                g: 180,
-                b: 250,
-            },
-            h3: Color::Rgb {
-                r: 203,
-                g: 166,
-                b: 247,
-            },
-            h4: Color::Rgb {
-                r: 166,
-                g: 227,
-                b: 161,
-            },
-            h5: Color::Rgb {
-                r: 249,
-                g: 226,
-                b: 175,
-            },
-            h6: Color::Rgb {
-                r: 127,
-                g: 132,
-                b: 156,
-            },
-            heading_separator: Color::Rgb {
-                r: 49,
-                g: 50,
-                b: 68,
-            },
-
-            code_bg: Color::Rgb {
-                r: 30,
-                g: 32,
-                b: 42,
-            },
-            code_border: Color::Rgb {
-                r: 68,
-                g: 71,
-                b: 90,
-            },
-            code_label: Color::Rgb {
-                r: 108,
-                g: 112,
-                b: 134,
-            },
+            code_bg: resolve_color!("code_bg", 30, 32, 42),
+            code_border: resolve_color!("code_border", 68, 71, 90),
+            code_label: resolve_color!("code_label", 108, 112, 134),
             syntect_theme: "base16-ocean.dark",
 
-            inline_code_fg: Color::Rgb {
-                r: 242,
-                g: 205,
-                b: 147,
-            },
-            inline_code_bg: Color::Rgb {
-                r: 40,
-                g: 42,
-                b: 54,
-            },
-            inline_code_tick: Color::Rgb {
-                r: 68,
-                g: 71,
-                b: 90,
-            },
+            inline_code_fg: resolve_color!("inline_code_fg", 242, 205, 147),
+            inline_code_bg: resolve_color!("inline_code_bg", 40, 42, 54),
+            inline_code_tick: resolve_color!("inline_code_tick", 68, 71, 90),
 
-            blockquote_bar: Color::Rgb {
-                r: 116,
-                g: 143,
-                b: 196,
-            },
+            blockquote_bar: resolve_color!("blockquote_bar", 116, 143, 196),
 
-            link: Color::Rgb {
-                r: 137,
-                g: 180,
-                b: 250,
-            },
-            link_url: Color::Rgb {
-                r: 108,
-                g: 112,
-                b: 134,
-            },
+            link: resolve_color!("link", 137, 180, 250),
+            link_url: resolve_color!("link_url", 108, 112, 134),
 
-            bullet: Color::Rgb {
-                r: 127,
-                g: 132,
-                b: 156,
-            },
-            task_done: Color::Rgb {
-                r: 166,
-                g: 227,
-                b: 161,
-            },
-            task_pending: Color::Rgb {
-                r: 108,
-                g: 112,
-                b: 134,
-            },
+            bullet: resolve_color!("bullet", 127, 132, 156),
+            task_done: resolve_color!("task_done", 166, 227, 161),
+            task_pending: resolve_color!("task_pending", 108, 112, 134),
 
-            rule: Color::Rgb {
-                r: 68,
-                g: 71,
-                b: 90,
-            },
+            rule: resolve_color!("rule", 68, 71, 90),
 
-            table_border: Color::Rgb {
-                r: 68,
-                g: 71,
-                b: 90,
-            },
-            table_header: Color::Rgb {
-                r: 137,
-                g: 180,
-                b: 250,
-            },
+            table_border: resolve_color!("table_border", 68, 71, 90),
+            table_header: resolve_color!("table_header", 137, 180, 250),
 
-            search_prompt: Color::Rgb {
-                r: 249,
-                g: 226,
-                b: 175,
-            },
-            search_match_bg: Color::Rgb {
-                r: 100,
-                g: 80,
-                b: 0,
-            },
-            search_current_bg: Color::Rgb {
-                r: 249,
-                g: 226,
-                b: 175,
-            },
-            search_current_fg: Color::Rgb {
-                r: 24,
-                g: 24,
-                b: 37,
-            },
-            search_no_match: Color::Rgb {
-                r: 243,
-                g: 139,
-                b: 168,
-            },
+            search_prompt: resolve_color!("search_prompt", 249, 226, 175),
+            search_match_bg: resolve_color!("search_match_bg", 100, 80, 0),
+            search_current_bg: resolve_color!("search_current_bg", 249, 226, 175),
+            search_current_fg: resolve_color!("search_current_fg", 24, 24, 37),
+            search_no_match: resolve_color!("search_no_match", 243, 139, 168),
 
-            overlay_bg: Color::Rgb {
-                r: 36,
-                g: 39,
-                b: 58,
-            },
-            overlay_border: Color::Rgb {
-                r: 91,
-                g: 96,
-                b: 120,
-            },
-            overlay_selected_bg: Color::Rgb {
-                r: 68,
-                g: 71,
-                b: 90,
-            },
-            overlay_selected_fg: Color::Rgb {
-                r: 205,
-                g: 214,
-                b: 244,
-            },
-            overlay_text: Color::Rgb {
-                r: 186,
-                g: 194,
-                b: 222,
-            },
-            overlay_muted: Color::Rgb {
-                r: 108,
-                g: 112,
-                b: 134,
-            },
+            overlay_bg: resolve_color!("overlay_bg", 36, 39, 58),
+            overlay_border: resolve_color!("overlay_border", 91, 96, 120),
+            overlay_selected_bg: resolve_color!("overlay_selected_bg", 68, 71, 90),
+            overlay_selected_fg: resolve_color!("overlay_selected_fg", 205, 214, 244),
+            overlay_text: resolve_color!("overlay_text", 186, 194, 222),
+            overlay_muted: resolve_color!("overlay_muted", 108, 112, 134),
 
-            image_fg: Color::Rgb {
-                r: 166,
-                g: 227,
-                b: 161,
-            },
-            slide_indicator: Color::Rgb {
-                r: 249,
-                g: 226,
-                b: 175,
-            },
-            math_fg: Color::Rgb {
-                r: 242,
-                g: 205,
-                b: 147,
-            },
-            line_number: Color::Rgb {
-                r: 68,
-                g: 71,
-                b: 90,
-            },
+            image_fg: resolve_color!("image_fg", 166, 227, 161),
 
-            json_key: Color::Rgb {
-                r: 137,
-                g: 180,
-                b: 250,
-            },
-            json_string: Color::Rgb {
-                r: 166,
-                g: 227,
-                b: 161,
-            },
-            json_number: Color::Rgb {
-                r: 250,
-                g: 179,
-                b: 135,
-            },
-            json_bool: Color::Rgb {
-                r: 249,
-                g: 226,
-                b: 175,
-            },
-            json_null: Color::Rgb {
-                r: 108,
-                g: 112,
-                b: 134,
-            },
-            json_bracket: Color::Rgb {
-                r: 127,
-                g: 132,
-                b: 156,
-            },
-            json_path: Color::Rgb {
-                r: 203,
-                g: 166,
-                b: 247,
-            },
-            json_focus_bg: Color::Rgb {
-                r: 40,
-                g: 42,
-                b: 54,
-            },
+            slide_indicator: resolve_color!("slide_indicator", 249, 226, 175),
+
+            math_fg: resolve_color!("math_fg", 242, 205, 147),
+
+            line_number: resolve_color!("line_number", 68, 71, 90),
+
+            json_key: resolve_color!("json_key", 137, 180, 250),
+            json_string: resolve_color!("json_string", 166, 227, 161),
+            json_number: resolve_color!("json_number", 250, 179, 135),
+            json_bool: resolve_color!("json_bool", 249, 226, 175),
+            json_null: resolve_color!("json_null", 108, 112, 134),
+            json_bracket: resolve_color!("json_bracket", 127, 132, 156),
+            json_path: resolve_color!("json_path", 203, 166, 247),
+            json_focus_bg: resolve_color!("json_focus_bg", 40, 42, 54),
         }
     }
 
     pub fn light() -> Self {
+        let config = Config::load();
+        let overrides = load_theme_overrides(config.theme_light);
+
+        macro_rules! resolve_color {
+            ($key:expr, $r:expr, $g:expr, $b:expr) => {
+                overrides.get($key).copied().unwrap_or(Color::Rgb {
+                    r: $r,
+                    g: $g,
+                    b: $b,
+                })
+            };
+        }
+
         Self {
             is_dark: false,
 
-            bg: Color::Rgb {
-                r: 239,
-                g: 241,
-                b: 245,
-            },
-            fg: Color::Rgb {
-                r: 76,
-                g: 79,
-                b: 105,
-            },
+            bg: resolve_color!("bg", 239, 241, 245),
+            fg: resolve_color!("fg", 76, 79, 105),
 
-            border: Color::Rgb {
-                r: 172,
-                g: 176,
-                b: 190,
-            },
-            title: Color::Rgb {
-                r: 92,
-                g: 95,
-                b: 119,
-            },
-            position: Color::Rgb {
-                r: 108,
-                g: 111,
-                b: 133,
-            },
-            help_hint: Color::Rgb {
-                r: 140,
-                g: 143,
-                b: 161,
-            },
-            scrollbar_track: Color::Rgb {
-                r: 204,
-                g: 208,
-                b: 218,
-            },
-            scrollbar_thumb: Color::Rgb {
-                r: 140,
-                g: 143,
-                b: 161,
-            },
+            border: resolve_color!("border", 172, 176, 190),
+            title: resolve_color!("title", 92, 95, 119),
+            position: resolve_color!("position", 108, 111, 133),
+            help_hint: resolve_color!("help_hint", 140, 143, 161),
+            scrollbar_track: resolve_color!("scrollbar_track", 204, 208, 218),
+            scrollbar_thumb: resolve_color!("scrollbar_thumb", 140, 143, 161),
 
-            h1: Color::Rgb {
-                r: 32,
-                g: 32,
-                b: 42,
-            },
-            h2: Color::Rgb {
-                r: 30,
-                g: 102,
-                b: 245,
-            },
-            h3: Color::Rgb {
-                r: 136,
-                g: 57,
-                b: 239,
-            },
-            h4: Color::Rgb {
-                r: 64,
-                g: 160,
-                b: 43,
-            },
-            h5: Color::Rgb {
-                r: 223,
-                g: 142,
-                b: 29,
-            },
-            h6: Color::Rgb {
-                r: 108,
-                g: 111,
-                b: 133,
-            },
-            heading_separator: Color::Rgb {
-                r: 204,
-                g: 208,
-                b: 218,
-            },
+            h1: resolve_color!("h1", 32, 32, 42),
+            h2: resolve_color!("h2", 30, 102, 245),
+            h3: resolve_color!("h3", 136, 57, 239),
+            h4: resolve_color!("h4", 64, 160, 43),
+            h5: resolve_color!("h5", 223, 142, 29),
+            h6: resolve_color!("h6", 108, 111, 133),
+            heading_separator: resolve_color!("heading_separator", 204, 208, 218),
 
-            code_bg: Color::Rgb {
-                r: 239,
-                g: 241,
-                b: 245,
-            },
-            code_border: Color::Rgb {
-                r: 188,
-                g: 192,
-                b: 204,
-            },
-            code_label: Color::Rgb {
-                r: 124,
-                g: 127,
-                b: 147,
-            },
+            code_bg: resolve_color!("code_bg", 239, 241, 245),
+            code_border: resolve_color!("code_border", 188, 192, 204),
+            code_label: resolve_color!("code_label", 124, 127, 147),
             syntect_theme: "InspiredGitHub",
 
-            inline_code_fg: Color::Rgb {
-                r: 179,
-                g: 82,
-                b: 2,
-            },
-            inline_code_bg: Color::Rgb {
-                r: 230,
-                g: 233,
-                b: 239,
-            },
-            inline_code_tick: Color::Rgb {
-                r: 172,
-                g: 176,
-                b: 190,
-            },
+            inline_code_fg: resolve_color!("inline_code_fg", 179, 82, 2),
+            inline_code_bg: resolve_color!("inline_code_bg", 230, 233, 239),
+            inline_code_tick: resolve_color!("inline_code_tick", 172, 176, 190),
 
-            blockquote_bar: Color::Rgb {
-                r: 30,
-                g: 102,
-                b: 245,
-            },
+            blockquote_bar: resolve_color!("blockquote_bar", 30, 102, 245),
 
-            link: Color::Rgb {
-                r: 30,
-                g: 102,
-                b: 245,
-            },
-            link_url: Color::Rgb {
-                r: 140,
-                g: 143,
-                b: 161,
-            },
+            link: resolve_color!("link", 30, 102, 245),
+            link_url: resolve_color!("link_url", 140, 143, 161),
 
-            bullet: Color::Rgb {
-                r: 108,
-                g: 111,
-                b: 133,
-            },
-            task_done: Color::Rgb {
-                r: 64,
-                g: 160,
-                b: 43,
-            },
-            task_pending: Color::Rgb {
-                r: 140,
-                g: 143,
-                b: 161,
-            },
+            bullet: resolve_color!("bullet", 108, 111, 133),
+            task_done: resolve_color!("task_done", 64, 160, 43),
+            task_pending: resolve_color!("task_pending", 140, 143, 161),
 
-            rule: Color::Rgb {
-                r: 188,
-                g: 192,
-                b: 204,
-            },
+            rule: resolve_color!("rule", 188, 192, 204),
 
-            table_border: Color::Rgb {
-                r: 188,
-                g: 192,
-                b: 204,
-            },
-            table_header: Color::Rgb {
-                r: 30,
-                g: 102,
-                b: 245,
-            },
+            table_border: resolve_color!("table_border", 188, 192, 204),
+            table_header: resolve_color!("table_header", 30, 102, 245),
 
-            search_prompt: Color::Rgb {
-                r: 223,
-                g: 142,
-                b: 29,
-            },
-            search_match_bg: Color::Rgb {
-                r: 255,
-                g: 235,
-                b: 160,
-            },
-            search_current_bg: Color::Rgb {
-                r: 253,
-                g: 205,
-                b: 54,
-            },
-            search_current_fg: Color::Rgb {
-                r: 32,
-                g: 32,
-                b: 42,
-            },
-            search_no_match: Color::Rgb {
-                r: 210,
-                g: 15,
-                b: 57,
-            },
+            search_prompt: resolve_color!("search_prompt", 223, 142, 29),
+            search_match_bg: resolve_color!("search_match_bg", 255, 235, 160),
+            search_current_bg: resolve_color!("search_current_bg", 253, 205, 54),
+            search_current_fg: resolve_color!("search_current_fg", 32, 32, 42),
+            search_no_match: resolve_color!("search_no_match", 210, 15, 57),
 
-            overlay_bg: Color::Rgb {
-                r: 230,
-                g: 233,
-                b: 239,
-            },
-            overlay_border: Color::Rgb {
-                r: 172,
-                g: 176,
-                b: 190,
-            },
-            overlay_selected_bg: Color::Rgb {
-                r: 188,
-                g: 192,
-                b: 204,
-            },
-            overlay_selected_fg: Color::Rgb {
-                r: 76,
-                g: 79,
-                b: 105,
-            },
-            overlay_text: Color::Rgb {
-                r: 76,
-                g: 79,
-                b: 105,
-            },
-            overlay_muted: Color::Rgb {
-                r: 140,
-                g: 143,
-                b: 161,
-            },
+            overlay_bg: resolve_color!("overlay_bg", 230, 233, 239),
+            overlay_border: resolve_color!("overlay_border", 172, 176, 190),
+            overlay_selected_bg: resolve_color!("overlay_selected_bg", 188, 192, 204),
+            overlay_selected_fg: resolve_color!("overlay_selected_fg", 76, 79, 105),
+            overlay_text: resolve_color!("overlay_text", 76, 79, 105),
+            overlay_muted: resolve_color!("overlay_muted", 140, 143, 161),
 
-            image_fg: Color::Rgb {
-                r: 64,
-                g: 160,
-                b: 43,
-            },
-            slide_indicator: Color::Rgb {
-                r: 223,
-                g: 142,
-                b: 29,
-            },
-            math_fg: Color::Rgb {
-                r: 179,
-                g: 82,
-                b: 2,
-            },
-            line_number: Color::Rgb {
-                r: 172,
-                g: 176,
-                b: 190,
-            },
+            image_fg: resolve_color!("image_fg", 64, 160, 43),
 
-            json_key: Color::Rgb {
-                r: 30,
-                g: 102,
-                b: 245,
-            },
-            json_string: Color::Rgb {
-                r: 64,
-                g: 160,
-                b: 43,
-            },
-            json_number: Color::Rgb {
-                r: 254,
-                g: 100,
-                b: 11,
-            },
-            json_bool: Color::Rgb {
-                r: 223,
-                g: 142,
-                b: 29,
-            },
-            json_null: Color::Rgb {
-                r: 140,
-                g: 143,
-                b: 161,
-            },
-            json_bracket: Color::Rgb {
-                r: 108,
-                g: 111,
-                b: 133,
-            },
-            json_path: Color::Rgb {
-                r: 136,
-                g: 57,
-                b: 239,
-            },
-            json_focus_bg: Color::Rgb {
-                r: 220,
-                g: 224,
-                b: 232,
-            },
+            slide_indicator: resolve_color!("slide_indicator", 223, 142, 29),
+
+            math_fg: resolve_color!("math_fg", 179, 82, 2),
+
+            line_number: resolve_color!("line_number", 172, 176, 190),
+
+            json_key: resolve_color!("json_key", 30, 102, 245),
+            json_string: resolve_color!("json_string", 64, 160, 43),
+            json_number: resolve_color!("json_number", 254, 100, 11),
+            json_bool: resolve_color!("json_bool", 223, 142, 29),
+            json_null: resolve_color!("json_null", 140, 143, 161),
+            json_bracket: resolve_color!("json_bracket", 108, 111, 133),
+            json_path: resolve_color!("json_path", 136, 57, 239),
+            json_focus_bg: resolve_color!("json_focus_bg", 220, 224, 232),
         }
     }
 
@@ -672,10 +319,5 @@ impl Theme {
         } else {
             Self::dark()
         }
-    }
-
-    #[allow(dead_code)]
-    pub fn name(&self) -> &'static str {
-        if self.is_dark { "dark" } else { "light" }
     }
 }

--- a/themes/ayu-dark.toml
+++ b/themes/ayu-dark.toml
@@ -1,0 +1,71 @@
+# Ayu Dark
+bg = "0f1419"
+fg = "e6e1cf"
+
+# UI Elements
+border = "1a232c"
+title = "5c6773"
+position = "36a3d9"
+help_hint = "4c5561"
+scrollbar_track = "0b0e14"
+scrollbar_thumb = "243340"
+
+# Headings
+h1 = "ff3333"
+h2 = "ffb454"
+h3 = "f29718"
+h4 = "7fd962"
+h5 = "34bfd0"
+h6 = "f07178"
+heading_separator = "1a232c"
+
+# Code blocks & Inline code
+code_bg = "0b0e14"
+code_border = "1a232c"
+code_label = "ffb454"
+inline_code_fg = "e7c547"
+inline_code_bg = "1a232c"
+inline_code_tick = "243340"
+
+# Blockquote & Links
+blockquote_bar = "f29718"
+link = "36a3d9"
+link_url = "4c5561"
+
+# Lists & Tables
+bullet = "ffb454"
+task_done = "7fd962"
+task_pending = "4c5561"
+rule = "1a232c"
+table_border = "1a232c"
+table_header = "ffb454"
+
+# Search UI & Overlays
+search_prompt = "f29718"
+search_match_bg = "243340"
+search_current_bg = "ffb454"
+search_current_fg = "0f1419"
+search_no_match = "ff3333"
+overlay_bg = "0b0e14"
+overlay_border = "36a3d9"
+overlay_selected_bg = "1a232c"
+overlay_selected_fg = "e6e1cf"
+
+overlay_text = "e6e1cf"
+overlay_muted = "4c5561"
+
+# Elements & Markdown syntax
+image_fg = "7fd962"
+slide_indicator = "f29718"
+math_fg = "34bfd0"
+line_number = "243340"
+
+# JSON Syntax Highlighting
+json_key = "ffb454"
+json_string = "7fd962"
+json_number = "b8cc52"
+json_bool = "f29718"
+json_null = "4c5561"
+json_bracket = "e6e1cf"
+json_path = "36a3d9"
+json_focus_bg = "1a232c"

--- a/themes/dracula.toml
+++ b/themes/dracula.toml
@@ -1,0 +1,70 @@
+# Dracula Theme
+bg = "282a36"
+fg = "f8f8f2"
+
+# UI Elements
+border = "44475a"
+title = "6272a4"
+position = "8be9fd"
+help_hint = "6272a4"
+scrollbar_track = "1e1f29"
+scrollbar_thumb = "44475a"
+
+# Headings
+h1 = "ff79c6"
+h2 = "bd93f9"
+h3 = "8be9fd"
+h4 = "50fa7b"
+h5 = "f1fa8c"
+h6 = "ffb86c"
+heading_separator = "44475a"
+
+# Code blocks & Inline code
+code_bg = "1e1f29"
+code_border = "44475a"
+code_label = "6272a4"
+inline_code_fg = "ffb86c"
+inline_code_bg = "44475a"
+inline_code_tick = "6272a4"
+
+# Blockquote & Links
+blockquote_bar = "bd93f9"
+link = "8be9fd"
+link_url = "6272a4"
+
+# Lists & Tables
+bullet = "bd93f9"
+task_done = "50fa7b"
+task_pending = "6272a4"
+rule = "44475a"
+table_border = "44475a"
+table_header = "ff79c6"
+
+# Search UI & Overlays
+search_prompt = "f1fa8c"
+search_match_bg = "44475a"
+search_current_bg = "ff79c6"
+search_current_fg = "282a36"
+search_no_match = "ff5555"
+overlay_bg = "1e1f29"
+overlay_border = "bd93f9"
+overlay_selected_bg = "44475a"
+overlay_selected_fg = "f8f8f2"
+overlay_text = "f8f8f2"
+overlay_muted = "6272a4"
+
+# Elements & Markdown syntax
+image_fg = "50fa7b"
+slide_indicator = "f1fa8c"
+math_fg = "8be9fd"
+line_number = "6272a4"
+
+# JSON Syntax Highlighting
+json_key = "ff79c6"
+json_string = "50fa7b"
+json_number = "bd93f9"
+json_bool = "ffb86c"
+json_null = "6272a4"
+json_bracket = "f8f8f2"
+json_path = "8be9fd"
+json_focus_bg = "44475a"

--- a/themes/everforest-dark.toml
+++ b/themes/everforest-dark.toml
@@ -1,0 +1,70 @@
+# Everforest Dark (Medium Variant)
+bg = "2d353b"
+fg = "d3c6aa"
+
+# UI Elements
+border = "3d484d"
+title = "859289"
+position = "7fbbb3"
+help_hint = "7a8478"
+scrollbar_track = "232a2e"
+scrollbar_thumb = "475258"
+
+# Headings
+h1 = "e67e80"
+h2 = "7fbbb3"
+h3 = "dbbc7f"
+h4 = "a7c080"
+h5 = "d699b6"
+h6 = "9da9a0"
+heading_separator = "3d484d"
+
+# Code blocks & Inline code
+code_bg = "232a2e"
+code_border = "3d484d"
+code_label = "859289"
+inline_code_fg = "e69875"
+inline_code_bg = "3d484d"
+inline_code_tick = "475258"
+
+# Blockquote & Links
+blockquote_bar = "d699b6"
+link = "7fbbb3"
+link_url = "7a8478"
+
+# Lists & Tables
+bullet = "d699b6"
+task_done = "a7c080"
+task_pending = "7a8478"
+rule = "3d484d"
+table_border = "3d484d"
+table_header = "7fbbb3"
+
+# Search UI & Overlays
+search_prompt = "dbbc7f"
+search_match_bg = "475258"
+search_current_bg = "e67e80"
+search_current_fg = "2d353b"
+search_no_match = "e67e80"
+overlay_bg = "232a2e"
+overlay_border = "7fbbb3"
+overlay_selected_bg = "3d484d"
+overlay_selected_fg = "d3c6aa"
+overlay_text = "d3c6aa"
+overlay_muted = "7a8478"
+
+# Elements & Markdown syntax
+image_fg = "a7c080"
+slide_indicator = "dbbc7f"
+math_fg = "83c092"
+line_number = "475258"
+
+# JSON Syntax Highlighting
+json_key = "e67e80"
+json_string = "a7c080"
+json_number = "d699b6"
+json_bool = "e69875"
+json_null = "7a8478"
+json_bracket = "d3c6aa"
+json_path = "7fbbb3"
+json_focus_bg = "3d484d"

--- a/themes/everforest-light.toml
+++ b/themes/everforest-light.toml
@@ -1,0 +1,70 @@
+# Everforest Light (Medium Variant)
+bg = "fdf6e3"
+fg = "5c6a72"
+
+# UI Elements
+border = "e8e5d5"
+title = "939f91"
+position = "35a1c1"
+help_hint = "83c092"
+scrollbar_track = "f4edd8"
+scrollbar_thumb = "dfdac9"
+
+# Headings
+h1 = "f85552"
+h2 = "35a1c1"
+h3 = "dfa000"
+h4 = "8da101"
+h5 = "df69ba"
+h6 = "939f91"
+heading_separator = "e8e5d5"
+
+# Code blocks & Inline code
+code_bg = "f4edd8"
+code_border = "e8e5d5"
+code_label = "939f91"
+inline_code_fg = "f57d26"
+inline_code_bg = "e8e5d5"
+inline_code_tick = "dfdac9"
+
+# Blockquote & Links
+blockquote_bar = "df69ba"
+link = "35a1c1"
+link_url = "8da101"
+
+# Lists & Tables
+bullet = "df69ba"
+task_done = "8da101"
+task_pending = "939f91"
+rule = "e8e5d5"
+table_border = "e8e5d5"
+table_header = "35a1c1"
+
+# Search UI & Overlays
+search_prompt = "dfa000"
+search_match_bg = "dfdac9"
+search_current_bg = "f85552"
+search_current_fg = "fdf6e3"
+search_no_match = "f85552"
+overlay_bg = "f4edd8"
+overlay_border = "35a1c1"
+overlay_selected_bg = "e8e5d5"
+overlay_selected_fg = "5c6a72"
+overlay_text = "5c6a72"
+overlay_muted = "939f91"
+
+# Elements & Markdown syntax
+image_fg = "8da101"
+slide_indicator = "dfa000"
+math_fg = "3a94c5"
+line_number = "dfdac9"
+
+# JSON Syntax Highlighting
+json_key = "f85552"
+json_string = "8da101"
+json_number = "df69ba"
+json_bool = "f57d26"
+json_null = "939f91"
+json_bracket = "5c6a72"
+json_path = "35a1c1"
+json_focus_bg = "e8e5d5"

--- a/themes/github-dark.toml
+++ b/themes/github-dark.toml
@@ -1,0 +1,70 @@
+# GitHub Dark Standard Palette
+bg = "0d1117"
+fg = "e6edf3"
+
+# UI Elements
+border = "30363d"
+title = "7d8590"
+position = "2f81f7"
+help_hint = "6e7681"
+scrollbar_track = "161b22"
+scrollbar_thumb = "30363d"
+
+# Headings
+h1 = "e6edf3"
+h2 = "2f81f7"
+h3 = "e6edf3"
+h4 = "3fb950"
+h5 = "db6d28"
+h6 = "8b949e"
+heading_separator = "30363d"
+
+# Code blocks & Inline code
+code_bg = "161b22"
+code_border = "30363d"
+code_label = "7d8590"
+inline_code_fg = "e6edf3"
+inline_code_bg = "6e7681"
+inline_code_tick = "30363d"
+
+# Blockquote & Links
+blockquote_bar = "30363d"
+link = "2f81f7"
+link_url = "8b949e"
+
+# Lists & Tables
+bullet = "7d8590"
+task_done = "3fb950"
+task_pending = "8b949e"
+rule = "30363d"
+table_border = "30363d"
+table_header = "2f81f7"
+
+# Search UI & Overlays
+search_prompt = "d29922"
+search_match_bg = "382e1e"
+search_current_bg = "f1e05a"
+search_current_fg = "0d1117"
+search_no_match = "f85149"
+overlay_bg = "161b22"
+overlay_border = "2f81f7"
+overlay_selected_bg = "21262d"
+overlay_selected_fg = "e6edf3"
+overlay_text = "e6edf3"
+overlay_muted = "8b949e"
+
+# Elements & Markdown syntax
+image_fg = "3fb950"
+slide_indicator = "d29922"
+math_fg = "79c0ff"
+line_number = "484f58"
+
+# JSON Syntax Highlighting
+json_key = "79c0ff"
+json_string = "a5d6ff"
+json_number = "79c0ff"
+json_bool = "ff7b72"
+json_null = "8b949e"
+json_bracket = "8b949e"
+json_path = "d29922"
+json_focus_bg = "21262d"

--- a/themes/github-light.toml
+++ b/themes/github-light.toml
@@ -1,0 +1,70 @@
+# GitHub Light Standard Palette
+bg = "ffffff"
+fg = "1f2328"
+
+# UI Elements
+border = "d0d7de"
+title = "57606a"
+position = "0969da"
+help_hint = "6e7781"
+scrollbar_track = "f6f8fa"
+scrollbar_thumb = "d0d7de"
+
+# Headings
+h1 = "1f2328"
+h2 = "0969da"
+h3 = "1f2328"
+h4 = "22863a"
+h5 = "e36209"
+h6 = "6e7781"
+heading_separator = "d0d7de"
+
+# Code blocks & Inline code
+code_bg = "f6f8fa"
+code_border = "d0d7de"
+code_label = "57606a"
+inline_code_fg = "1f2328"
+inline_code_bg = "afb8c1"
+inline_code_tick = "d0d7de"
+
+# Blockquote & Links
+blockquote_bar = "d0d7de"
+link = "0969da"
+link_url = "6e7781"
+
+# Lists & Tables
+bullet = "57606a"
+task_done = "1a7f37"
+task_pending = "6e7781"
+rule = "d0d7de"
+table_border = "d0d7de"
+table_header = "1f2328"
+
+# Search UI & Overlays
+search_prompt = "9a6700"
+search_match_bg = "ffe599"
+search_current_bg = "ffa23e"
+search_current_fg = "1f2328"
+search_no_match = "cf222e"
+overlay_bg = "f6f8fa"
+overlay_border = "0969da"
+overlay_selected_bg = "eaeef2"
+overlay_selected_fg = "1f2328"
+overlay_text = "1f2328"
+overlay_muted = "6e7781"
+
+# Elements & Markdown syntax
+image_fg = "1a7f37"
+slide_indicator = "9a6700"
+math_fg = "0550ae"
+line_number = "57606a"
+
+# JSON Syntax Highlighting
+json_key = "0550ae"
+json_string = "0a3069"
+json_number = "0550ae"
+json_bool = "cf222e"
+json_null = "6e7781"
+json_bracket = "24292f"
+json_path = "953800"
+json_focus_bg = "eaeef2"

--- a/themes/monokai-pro.toml
+++ b/themes/monokai-pro.toml
@@ -1,0 +1,69 @@
+bg = "2d2a2e"
+fg = "fcfcfa"
+
+# UI Elements
+border = "403e41"
+title = "939293"
+position = "727072"
+help_hint = "5b595c"
+scrollbar_track = "19181a"
+scrollbar_thumb = "5b595c"
+
+# Headings
+h1 = "ff6188"
+h2 = "fc9867"
+h3 = "ffd866"
+h4 = "a9dc76"
+h5 = "78dce8"
+h6 = "ab9df2"
+heading_separator = "403e41"
+
+# Code blocks & Inline code
+code_bg = "242225"
+code_border = "403e41"
+code_label = "727072"
+inline_code_fg = "fc9867"
+inline_code_bg = "363337"
+inline_code_tick = "403e41"
+
+# Blockquote & Links
+blockquote_bar = "ab9df2"
+link = "78dce8"
+link_url = "727072"
+
+# Lists & Tables
+bullet = "ab9df2"
+task_done = "a9dc76"
+task_pending = "5b595c"
+rule = "403e41"
+table_border = "48454A"
+table_header = "fc9867"
+
+# Search UI & Overlays
+search_prompt = "ffd866"
+search_match_bg = "403e41"
+search_current_bg = "ffd866"
+search_current_fg = "19181a"
+search_no_match = "ff6188"
+overlay_bg = "221f22"
+overlay_border = "403e41"
+overlay_selected_bg = "363337"
+overlay_selected_fg = "fcfcfa"
+overlay_text = "c1c0c0"
+overlay_muted = "727072"
+
+# Elements & Markdown syntax
+image_fg = "a9dc76"
+slide_indicator = "ffd866"
+math_fg = "78dce8"
+line_number = "5b595c"
+
+# JSON Syntax Highlighting
+json_key = "ff6188"
+json_string = "a9dc76"
+json_number = "ab9df2"
+json_bool = "fc9867"
+json_null = "727072"
+json_bracket = "c1c0c0"
+json_path = "78dce8"
+json_focus_bg = "363337"

--- a/themes/rose-pine.toml
+++ b/themes/rose-pine.toml
@@ -1,0 +1,70 @@
+# Rosé Pine (Dark Variant)
+bg = "191724"
+fg = "e0def4"
+
+# UI Elements
+border = "26233a"
+title = "908caa"
+position = "9ccfd8"
+help_hint = "6e6a86"
+scrollbar_track = "1f1d2e"
+scrollbar_thumb = "403d52"
+
+# Headings
+h1 = "ebbcba"
+h2 = "31748f"
+h3 = "f6c177"
+h4 = "eb6f92"
+h5 = "c4a7e7"
+h6 = "908caa"
+heading_separator = "26233a"
+
+# Code blocks & Inline code
+code_bg = "1f1d2e"
+code_border = "26233a"
+code_label = "908caa"
+inline_code_fg = "f6c177"
+inline_code_bg = "26233a"
+inline_code_tick = "403d52"
+
+# Blockquote & Links
+blockquote_bar = "c4a7e7"
+link = "31748f"
+link_url = "6e6a86"
+
+# Lists & Tables
+bullet = "c4a7e7"
+task_done = "9ccfd8"
+task_pending = "6e6a86"
+rule = "26233a"
+table_border = "26233a"
+table_header = "31748f"
+
+# Search UI & Overlays
+search_prompt = "f6c177"
+search_match_bg = "403d52"
+search_current_bg = "ebbcba"
+search_current_fg = "191724"
+search_no_match = "eb6f92"
+overlay_bg = "1f1d2e"
+overlay_border = "c4a7e7"
+overlay_selected_bg = "26233a"
+overlay_selected_fg = "e0def4"
+overlay_text = "e0def4"
+overlay_muted = "6e6a86"
+
+# Elements & Markdown syntax
+image_fg = "9ccfd8"
+slide_indicator = "f6c177"
+math_fg = "31748f"
+line_number = "403d52"
+
+# JSON Syntax Highlighting
+json_key = "ebbcba"
+json_string = "31748f"
+json_number = "c4a7e7"
+json_bool = "f6c177"
+json_null = "6e6a86"
+json_bracket = "e0def4"
+json_path = "9ccfd8"
+json_focus_bg = "26233a"

--- a/themes/tokyonight.toml
+++ b/themes/tokyonight.toml
@@ -1,0 +1,70 @@
+# Tokyo Night (Night Variant)
+bg = "1a1b26"
+fg = "a9b1d6"
+
+# UI Elements
+border = "24283b"
+title = "7aa2f7"
+position = "0db9d7"
+help_hint = "565f89"
+scrollbar_track = "16161e"
+scrollbar_thumb = "3b4261"
+
+# Headings
+h1 = "f7768e"
+h2 = "7aa2f7"
+h3 = "bb9af3"
+h4 = "9ece6a"
+h5 = "e0af68"
+h6 = "565f89"
+heading_separator = "24283b"
+
+# Code blocks & Inline code
+code_bg = "16161e"
+code_border = "24283b"
+code_label = "7aa2f7"
+inline_code_fg = "ff9e64"
+inline_code_bg = "24283b"
+inline_code_tick = "565f89"
+
+# Blockquote & Links
+blockquote_bar = "bb9af3"
+link = "7aa2f7"
+link_url = "565f89"
+
+# Lists & Tables
+bullet = "b4f9f8"
+task_done = "9ece6a"
+task_pending = "565f89"
+rule = "24283b"
+table_border = "24283b"
+table_header = "7aa2f7"
+
+# Search UI & Overlays
+search_prompt = "e0af68"
+search_match_bg = "3d59a1"
+search_current_bg = "ff9e64"
+search_current_fg = "16161e"
+search_no_match = "f7768e"
+overlay_bg = "16161e"
+overlay_border = "7aa2f7"
+overlay_selected_bg = "24283b"
+overlay_selected_fg = "a9b1d6"
+overlay_text = "a9b1d6"
+overlay_muted = "565f89"
+
+# Elements & Markdown syntax
+image_fg = "9ece6a"
+slide_indicator = "e0af68"
+math_fg = "7dcfff"
+line_number = "3b4261"
+
+# JSON Syntax Highlighting
+json_key = "7aa2f7"
+json_string = "9ece6a"
+json_number = "ff9e64"
+json_bool = "ff9e64"
+json_null = "565f89"
+json_bracket = "a9b1d6"
+json_path = "0db9d7"
+json_focus_bg = "24283b"


### PR DESCRIPTION
This commit introduces a layout configuration system that allows users to load custom colorschemes from external TOML files.

To support this, the global configuration parsing in `config.rs` was extended with two new options: `theme_dark` and `theme_light`. These fields look for corresponding `.toml` files inside `~/.config/mdterm/themes/`. The core logic in `theme.rs` was refactored to dynamically parse these files

Additionally, 9 ready-to-use theme presets have been bundled as samples in the new `themes` folder.
And the `README.md` was updated to show the new configuration options.