### PR TITLE
fix(config): honor XDG_CONFIG_HOME on all platforms

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -39,5 +39,8 @@ impl Config {
 }
 
 fn config_path() -> Option<PathBuf> {
-    dirs::config_dir().map(|d| d.join("mdterm").join("config.toml"))
+    let base = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(dirs::config_dir)?;
+    Some(base.join("mdterm").join("config.toml"))
 }


### PR DESCRIPTION
On MacOS XDG_CONFIG_HOME is not checked and mdterm falls back on the platform default config directory. When figuring out config_path, check if XDG_CONFIG_HOME is set explicitly on all platforms.

Fixes: #66